### PR TITLE
Add django-rosetta PR #293 contribution

### DIFF
--- a/_experiences/opensource.md
+++ b/_experiences/opensource.md
@@ -17,6 +17,6 @@ status: Active
 ---
 
 Various Open Source Contributions
-1. 
 
-
+1. **[django-rosetta #293](https://github.com/mbi/django-rosetta/pull/293)** — Python/Django — Merged Jul 6, 2024
+   Added the ability to override the OpenAI translation prompt with a custom template in django-rosetta. This allows users to provide more context for better translation quality when using OpenAI's GPT models for translating Django gettext files.


### PR DESCRIPTION
## What

Added my merged contribution to **[django-rosetta](https://github.com/mbi/django-rosetta/pull/293)** on the Open Source Contributions experience page.

### Summary

- **PR**: [mbi/django-rosetta #293](https://github.com/mbi/django-rosetta/pull/293)
- **What**: Allow overriding the OpenAI translation prompt with a custom template
- **Status**: Merged on Jul 6, 2024
- **Impact**: Users can now provide context-rich prompts for better GPT-based translations of Django gettext files